### PR TITLE
Fix postgres port in DATABASE_URL environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-export DATABASE_URL=postgres://localhost:5431/flakestry
+export DATABASE_URL=postgres://localhost:5432/flakestry
 export BASE_PATH=localhost:8888/api
 


### PR DESCRIPTION
The DATABASE_URL environment variable configures the port 5431 for sqlx-cli etc. The README instructs us to configure the postgres service on port 5432. This leads to connection issues when running the run-migrations script. This commit fixes this by correcting the DATABASE_URL environment variable to use port 5432 too.